### PR TITLE
Revert "version up 2.3.1"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,8 +43,8 @@ android {
         applicationId "io.github.rikuyu.contactlensreminder"
         minSdk 26
         targetSdk 31
-        versionCode 11
-        versionName "2.3.1"
+        versionCode 10
+        versionName "2.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Reverts rikuyu/contact-lens-reminder#83

中国語コードは「cn」ではなく「zh」らしい

<img width="486" alt="error" src="https://user-images.githubusercontent.com/51118613/166116067-cafe3fca-f1f7-4bb6-a358-d85f0560eca9.png">
